### PR TITLE
Modify settings for FOD2 farm

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -114,8 +114,8 @@ $wgResourceLoaderMaxQueryLength = -1;
 // allows users to remove the page title.
 $wgRestrictDisplayTitle = false;
 
-$wgUseRCPatrol = true;
-$wgUseNPPatrol = true;
+$wgUseRCPatrol = false;
+$wgUseNPPatrol = false;
 
 
 #

--- a/ExtensionSettings.php
+++ b/ExtensionSettings.php
@@ -76,7 +76,7 @@ $egExtensionLoaderConfig += array(
 
 	'SemanticInternalObjects' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticInternalObjects.git',
-		'branch' => 'REL1_23',
+		'tag' => '0.8.1',
 	),
 
 	'SemanticCompoundQueries' => array(
@@ -173,7 +173,7 @@ $egExtensionLoaderConfig += array(
 
 	'ApprovedRevs' => array(
 		'git' => 'https://github.com/jamesmontalvo3/MediaWiki-ApprovedRevs.git',
-		'branch' => 'master',
+		'branch' => 'fod2',
 		'globals' => array(
 			'egApprovedRevsAutomaticApprovals' => false,
 		),
@@ -256,9 +256,9 @@ $egExtensionLoaderConfig += array(
 	),
 
 	#
-	# Semantic Meeting Minutes 
+	# Semantic Meeting Minutes
 	#
-	#	
+	#
 	'SemanticMeetingMinutes' => array(
 		'git' => 'https://github.com/enterprisemediawiki/SemanticMeetingMinutes.git',
 		'branch' => 'master',

--- a/FodWikiSettings.php
+++ b/FodWikiSettings.php
@@ -2,11 +2,18 @@
 
 $egFodWikiSettings_GroupPathName = str_replace(' ','',$egFodWikiSettings_GroupName);
 
+/* * * * * * * * * * * * * * * * *
+ *                               *
+ * REMOVED FOR FOD2 Wiki Farming *
+ *                               *
+ * * * * * * * * * * * * * * * * *
+
 $wgSitename = $egFodWikiSettings_GroupName . ' Wiki';
 $wgMetaNamespace = str_replace(' ','_',$wgSitename);
 
 $wgEmergencyContact = str_replace(' ','-',$wgSitename) . '-Wiki@fod2.jsc.nasa.gov';
 $wgPasswordSender = $wgEmergencyContact;
+*/
 
 require_once "Includes/FodWikiSettings.body.php";
 $egFodWikiSettings_install_path = __DIR__;
@@ -18,7 +25,7 @@ if ( $egFodWikiSettings_debug ) {
 	error_reporting( -1 );
 	ini_set( 'display_errors', 1 );
 	ini_set( 'log_errors', 1 );
-	
+
 	// Output errors to log file
 	ini_set( 'error_log', __DIR__ . '/php.log' );
 
@@ -36,6 +43,13 @@ else {
 	ini_set("display_errors", 0);
 
 }
+
+
+/* * * * * * * * * * * * * * * * *
+ *                               *
+ * REMOVED FOR FOD2 Wiki Farming *
+ *                               *
+ * * * * * * * * * * * * * * * * *
 
 ## JSC FOD Wikis use mysql
 $wgDBtype = "mysql";
@@ -57,7 +71,7 @@ $wgStylePath        = "$wgScriptPath/skins";
 $wgLogo             = "$wgScriptPath/extensions/FodWikiSettings/Groups/$egFodWikiSettings_GroupPathName/logo.png";
 $wgFavicon          = "$wgScriptPath/extensions/FodWikiSettings/Groups/$egFodWikiSettings_GroupPathName/favicon.ico";
 $wgAppleTouchIcon   = "$wgScriptPath/extensions/FodWikiSettings/Groups/$egFodWikiSettings_GroupPathName/apple-touch-icon.png";
-
+*/
 
 /**
  *  FodWikiSettings specific javascript modifications
@@ -65,7 +79,7 @@ $wgAppleTouchIcon   = "$wgScriptPath/extensions/FodWikiSettings/Groups/$egFodWik
 $wgHooks['AjaxAddScript'][] = 'FodWikiSettings::addJSandCSS';
 
 
-## The following included script gets programmatically modified 
+## The following included script gets programmatically modified
 ## during backup operations to set read-only prior to backup and
 ## unset when backup is complete
 include "$egFodWikiSettings_install_path/Includes/wgReadOnly.php";

--- a/FodWikiSettings.php
+++ b/FodWikiSettings.php
@@ -1,12 +1,13 @@
 <?php
 
-$egFodWikiSettings_GroupPathName = str_replace(' ','',$egFodWikiSettings_GroupName);
 
 /* * * * * * * * * * * * * * * * *
  *                               *
  * REMOVED FOR FOD2 Wiki Farming *
  *                               *
  * * * * * * * * * * * * * * * * *
+
+$egFodWikiSettings_GroupPathName = str_replace(' ','',$egFodWikiSettings_GroupName);
 
 $wgSitename = $egFodWikiSettings_GroupName . ' Wiki';
 $wgMetaNamespace = str_replace(' ','_',$wgSitename);

--- a/Includes/Auth/settings_local_dev.php
+++ b/Includes/Auth/settings_local_dev.php
@@ -1,22 +1,22 @@
 <?php
 
-$wgGroupPermissions['*']['createaccount'] = false;
-$wgGroupPermissions['*']['read'] = false;
-$wgGroupPermissions['*']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['*']['createaccount'] = false;
+$GLOBALS['wgGroupPermissions']['*']['read'] = false;
+$GLOBALS['wgGroupPermissions']['*']['edit'] = false;
 
-$wgGroupPermissions['user']['talk'] = true; 
-$wgGroupPermissions['user']['read'] = true;
-$wgGroupPermissions['user']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['user']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['user']['read'] = true;
+$GLOBALS['wgGroupPermissions']['user']['edit'] = false;
 
 // Viewer group is used by the Auth_remoteuser extension to allow only those in
 // group "Viewer" to view the wiki. This allows anyone with NDC auth to get to the
 // wiki (which auto-creates an account for them), but doesn't allow those users to
 // see any of the wiki (besided the "access denied" page and "request access" page)
-$wgGroupPermissions['Viewer']['talk'] = true; 
-$wgGroupPermissions['Viewer']['read'] = true;
-$wgGroupPermissions['Viewer']['edit'] = false;
-$wgGroupPermissions['Viewer']['movefile'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['read'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['Viewer']['movefile'] = true;
 
-$wgGroupPermissions['Contributor'] = $wgGroupPermissions['user'];
-$wgGroupPermissions['Contributor']['edit'] = true;
-$wgGroupPermissions['Contributor']['unwatchedpages'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor'] = $GLOBALS['wgGroupPermissions']['user'];
+$GLOBALS['wgGroupPermissions']['Contributor']['edit'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor']['unwatchedpages'] = true;

--- a/Includes/Auth/settings_ndc_all.php
+++ b/Includes/Auth/settings_ndc_all.php
@@ -4,26 +4,24 @@
 // and http://www.mediawiki.org/w/Manual:Special_pages
 // and http://lists.wikimedia.org/pipermail/mediawiki-l/2009-June/031231.html
 // disable login and logout functions for all users
-function LessSpecialPages(&$list) {
-		unset( $list['Userlogout'] );
-		unset( $list['Userlogin'] );
-		return true;
-}
-$wgHooks['SpecialPage_initList'][]='LessSpecialPages';
- 
+$GLOBALS['wgHooks']['SpecialPage_initList'][] = function (&$list) {
+	unset( $list['Userlogout'] );
+	unset( $list['Userlogin'] );
+	return true;
+};
+
 // http://www.mediawiki.org/wiki/Extension:Windows_NTLM_LDAP_Auto_Auth
 // remove login and logout buttons for all users
-function StripLogin(&$personal_urls, &$wgTitle) {  
-		unset( $personal_urls["login"] );
-		unset( $personal_urls["logout"] );
-		unset( $personal_urls['anonlogin'] );
-		return true;
-}
-$wgHooks['PersonalUrls'][] = 'StripLogin';
+$GLOBALS['wgHooks']['PersonalUrls'][] = function (&$personal_urls, &$wgTitle) {
+	unset( $personal_urls["login"] );
+	unset( $personal_urls["logout"] );
+	unset( $personal_urls['anonlogin'] );
+	return true;
+};
 
 // for all types, no creating accounts, viewing or editing for anonymous users...because
 // there should not be any anonymous users. Everyone should automatically be logged in
 // with their network username, regardless of whether they are allowed to view/edit.
-$wgGroupPermissions['*']['createaccount'] = false;
-$wgGroupPermissions['*']['read'] = false;
-$wgGroupPermissions['*']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['*']['createaccount'] = false;
+$GLOBALS['wgGroupPermissions']['*']['read'] = false;
+$GLOBALS['wgGroupPermissions']['*']['edit'] = false;

--- a/Includes/Auth/settings_ndc_closed.php
+++ b/Includes/Auth/settings_ndc_closed.php
@@ -4,42 +4,42 @@ require_once dirname( __FILE__ ) . '/settings_ndc_all.php';
 
 // Auth_remoteuser extension, updated by James Montalvo, blocks remote users
 // who are not part of the group defined by $wgAuthRemoteuserViewerGroup
-$wgAuthRemoteuserViewerGroup = "Viewer"; // set to false to allow all valid REMOTE_USER to view; set to group name to restrict viewing to particular group
-$wgAuthRemoteuserDeniedPage = "Access_Denied"; // redirect non-viewers to this page (namespace below)
-$wgAuthRemoteuserDeniedNS = NS_PROJECT; // redirect non-viewers to page in this namespace
+$GLOBALS['wgAuthRemoteuserViewerGroup'] = "Viewer"; // set to false to allow all valid REMOTE_USER to view; set to group name to restrict viewing to particular group
+$GLOBALS['wgAuthRemoteuserDeniedPage'] = "Access_Denied"; // redirect non-viewers to this page (namespace below)
+$GLOBALS['wgAuthRemoteuserDeniedNS'] = NS_PROJECT; // redirect non-viewers to page in this namespace
 
 
-$wgGroupPermissions['user']['talk'] = true; 
-$wgGroupPermissions['user']['read'] = true;
-$wgGroupPermissions['user']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['user']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['user']['read'] = true;
+$GLOBALS['wgGroupPermissions']['user']['edit'] = false;
 
 // Viewer group is used by the Auth_remoteuser extension to allow only those in
 // group "Viewer" to view the wiki. This allows anyone with NDC auth to get to the
 // wiki (which auto-creates an account for them), but doesn't allow those users to
 // see any of the wiki (besided the "access denied" page and "request access" page)
-$wgGroupPermissions['Viewer']['talk'] = true; 
-$wgGroupPermissions['Viewer']['read'] = true;
-$wgGroupPermissions['Viewer']['edit'] = false;
-$wgGroupPermissions['Viewer']['movefile'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['read'] = true;
+$GLOBALS['wgGroupPermissions']['Viewer']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['Viewer']['movefile'] = true;
 
-$wgGroupPermissions['Contributor'] = $wgGroupPermissions['user'];
-$wgGroupPermissions['Contributor']['edit'] = true;
-$wgGroupPermissions['Contributor']['unwatchedpages'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor'] = $GLOBALS['wgGroupPermissions']['user'];
+$GLOBALS['wgGroupPermissions']['Contributor']['edit'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor']['unwatchedpages'] = true;
 
 #
 #   CURATORs: people with delete permissions for now
 #
-$wgGroupPermissions['Curator']['delete'] = true; // Delete pages
-$wgGroupPermissions['Curator']['bigdelete'] = true; // Delete pages with large histories
-$wgGroupPermissions['Curator']['suppressredirect'] = true; // Not create redirect when moving page
-$wgGroupPermissions['Curator']['browsearchive'] = true; // Search deleted pages
-$wgGroupPermissions['Curator']['undelete'] = true; // Undelete a page
-$wgGroupPermissions['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
-$wgGroupPermissions['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
+$GLOBALS['wgGroupPermissions']['Curator']['delete'] = true; // Delete pages
+$GLOBALS['wgGroupPermissions']['Curator']['bigdelete'] = true; // Delete pages with large histories
+$GLOBALS['wgGroupPermissions']['Curator']['suppressredirect'] = true; // Not create redirect when moving page
+$GLOBALS['wgGroupPermissions']['Curator']['browsearchive'] = true; // Search deleted pages
+$GLOBALS['wgGroupPermissions']['Curator']['undelete'] = true; // Undelete a page
+$GLOBALS['wgGroupPermissions']['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
+$GLOBALS['wgGroupPermissions']['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
 
 #
 #   MANAGERs: can edit user rights, plus used in MediaWiki:Approvedrevs-permissions
 #   to allow managers to give managers the ability to approve pages (lesson plans, ESOP, etc)
 #
-$wgGroupPermissions['Manager']['userrights'] = true; // Edit all user rights
+$GLOBALS['wgGroupPermissions']['Manager']['userrights'] = true; // Edit all user rights
 

--- a/Includes/Auth/settings_ndc_open.php
+++ b/Includes/Auth/settings_ndc_open.php
@@ -3,32 +3,32 @@
 require_once dirname( __FILE__ ) . '/settings_ndc_all.php';
 
 
-$wgGroupPermissions['user']['talk'] = true; 
-$wgGroupPermissions['user']['read'] = true;
-$wgGroupPermissions['user']['edit'] = true;
+$GLOBALS['wgGroupPermissions']['user']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['user']['read'] = true;
+$GLOBALS['wgGroupPermissions']['user']['edit'] = true;
 
 // Viewer group really only used in settings_ndc_closed.php
 // Set to the same as "user"
-$wgGroupPermissions['Viewer'] = $wgGroupPermissions['user']; 
+$GLOBALS['wgGroupPermissions']['Viewer'] = $GLOBALS['wgGroupPermissions']['user'];
 
 // Also same as user, with perhaps some additional privileges
-$wgGroupPermissions['Contributor'] = $wgGroupPermissions['user'];
-$wgGroupPermissions['Contributor']['unwatchedpages'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor'] = $GLOBALS['wgGroupPermissions']['user'];
+$GLOBALS['wgGroupPermissions']['Contributor']['unwatchedpages'] = true;
 
 #
 #   CURATORs: people with delete permissions for now
 #
-$wgGroupPermissions['Curator']['delete'] = true; // Delete pages
-$wgGroupPermissions['Curator']['bigdelete'] = true; // Delete pages with large histories
-$wgGroupPermissions['Curator']['suppressredirect'] = true; // Not create redirect when moving page
-$wgGroupPermissions['Curator']['browsearchive'] = true; // Search deleted pages
-$wgGroupPermissions['Curator']['undelete'] = true; // Undelete a page
-$wgGroupPermissions['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
-$wgGroupPermissions['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
+$GLOBALS['wgGroupPermissions']['Curator']['delete'] = true; // Delete pages
+$GLOBALS['wgGroupPermissions']['Curator']['bigdelete'] = true; // Delete pages with large histories
+$GLOBALS['wgGroupPermissions']['Curator']['suppressredirect'] = true; // Not create redirect when moving page
+$GLOBALS['wgGroupPermissions']['Curator']['browsearchive'] = true; // Search deleted pages
+$GLOBALS['wgGroupPermissions']['Curator']['undelete'] = true; // Undelete a page
+$GLOBALS['wgGroupPermissions']['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
+$GLOBALS['wgGroupPermissions']['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
 
 #
 #   MANAGERs: can edit user rights, plus used in MediaWiki:Approvedrevs-permissions
 #   to allow managers to give managers the ability to approve pages (lesson plans, ESOP, etc)
 #
-$wgGroupPermissions['Manager']['userrights'] = true; // Edit all user rights
+$GLOBALS['wgGroupPermissions']['Manager']['userrights'] = true; // Edit all user rights
 

--- a/Includes/Auth/settings_ndc_openview.php
+++ b/Includes/Auth/settings_ndc_openview.php
@@ -3,33 +3,33 @@
 require_once dirname( __FILE__ ) . '/settings_ndc_all.php';
 
 // all users can view and edit
-$wgGroupPermissions['user']['talk'] = true; 
-$wgGroupPermissions['user']['read'] = true;
-$wgGroupPermissions['user']['edit'] = false;
+$GLOBALS['wgGroupPermissions']['user']['talk'] = true;
+$GLOBALS['wgGroupPermissions']['user']['read'] = true;
+$GLOBALS['wgGroupPermissions']['user']['edit'] = false;
 
 // Viewer group really only used in settings_ndc_closed.php
 // Set to the same as "user"
-$wgGroupPermissions['Viewer'] = $wgGroupPermissions['user']; 
+$GLOBALS['wgGroupPermissions']['Viewer'] = $GLOBALS['wgGroupPermissions']['user'];
 
 // Set the same as all users, plus edit privileges
-$wgGroupPermissions['Contributor'] = $wgGroupPermissions['user'];
-$wgGroupPermissions['Contributor']['edit'] = true;
-$wgGroupPermissions['Contributor']['unwatchedpages'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor'] = $GLOBALS['wgGroupPermissions']['user'];
+$GLOBALS['wgGroupPermissions']['Contributor']['edit'] = true;
+$GLOBALS['wgGroupPermissions']['Contributor']['unwatchedpages'] = true;
 
 #
 #   CURATORs: people with delete permissions for now
 #
-$wgGroupPermissions['Curator']['delete'] = true; // Delete pages
-$wgGroupPermissions['Curator']['bigdelete'] = true; // Delete pages with large histories
-$wgGroupPermissions['Curator']['suppressredirect'] = true; // Not create redirect when moving page
-$wgGroupPermissions['Curator']['browsearchive'] = true; // Search deleted pages
-$wgGroupPermissions['Curator']['undelete'] = true; // Undelete a page
-$wgGroupPermissions['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
-$wgGroupPermissions['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
+$GLOBALS['wgGroupPermissions']['Curator']['delete'] = true; // Delete pages
+$GLOBALS['wgGroupPermissions']['Curator']['bigdelete'] = true; // Delete pages with large histories
+$GLOBALS['wgGroupPermissions']['Curator']['suppressredirect'] = true; // Not create redirect when moving page
+$GLOBALS['wgGroupPermissions']['Curator']['browsearchive'] = true; // Search deleted pages
+$GLOBALS['wgGroupPermissions']['Curator']['undelete'] = true; // Undelete a page
+$GLOBALS['wgGroupPermissions']['Curator']['deletedhistory'] = true; // View deleted history w/o associated text
+$GLOBALS['wgGroupPermissions']['Curator']['deletedtext'] = true; // View deleted text/changes between deleted revs
 
 #
 #   MANAGERs: can edit user rights, plus used in MediaWiki:Approvedrevs-permissions
 #   to allow managers to give managers the ability to approve pages (lesson plans, ESOP, etc)
 #
-$wgGroupPermissions['Manager']['userrights'] = true; // Edit all user rights
+$GLOBALS['wgGroupPermissions']['Manager']['userrights'] = true; // Edit all user rights
 

--- a/README.md
+++ b/README.md
@@ -26,18 +26,80 @@ Install this extension and ExtensionLoader (via git clone).
 ```
 <?php
 
-## Database settings
-$wgDBname     = "wiki_eva";
-include "$IP/../databaseCredentials.php";
+# Protect against web entry
+if ( !defined( 'MEDIAWIKI' ) ) {
+	exit;
+}
 
-## Used to generate Wiki name, email senders, path names, etc
-$egFodWikiSettings_GroupName = "EVA";
+// same value as bash variable in config.sh
+// $m_htdocs = 'D:/inetpub/wwwroot/PHP/Wiki';
+$m_htdocs = $IP . '/..';
 
-## Restrictions on who can view/edit
-$egFodWikiSettings_auth_type = "ndc_closed"; // (ndc_closed) for local_dev add $wgTmpDirectory = 'd:\Support\php\uploadtemp';
+if( $wgCommandLineMode ) {
 
-# Use JSC FOD Wiki Settings - github/enterprisemediawiki/FodWikiSettings
-require_once "$IP/extensions/FodWikiSettings/FodWikiSettings.php";
+	$mezaWikiEnvVarName='WIKI';
+
+	// get $wikiId from environment variable
+	$wikiId = getenv( $mezaWikiEnvVarName );
+
+}
+else {
+
+	// get $wikiId from URI
+	$uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
+	$wikiId = strtolower( $uriParts[2] ); // URI has leading slash, so $uriParts[0] is empty string, $uriParts[1] is "wiki"
+
+}
+
+// get all directory names in /wikis, minus the first two: . and ..
+$wikis = array_slice( scandir( "$m_htdocs/wikis" ), 2 );
+
+
+if ( ! in_array( $wikiId, $wikis ) ) {
+
+	// handle invalid wiki
+	die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
+
+}
+
+
+// Path of to images and config for this $wikiId
+$mezaWikiIP = "/wiki/wikis/$wikiId";
+
+// Get's wiki-specific config variables like:
+// $wgSitename, $mezaAuthType, $mezaDebug, $mezaEnableWikiEmail
+require_once "$m_htdocs/wikis/$wikiId/config/setup.php";
+
+
+// https://www.mediawiki.org/wiki/Manual:$wgScriptPath
+$wgScriptPath = "/wiki/$wikiId";
+
+// https://www.mediawiki.org/wiki/Manual:$wgUploadPath
+$wgUploadPath = "$mezaWikiIP/images";
+
+// https://www.mediawiki.org/wiki/Manual:$wgUploadDirectory
+$wgUploadDirectory = "$m_htdocs/wikis/$wikiId/images";
+
+// https://www.mediawiki.org/wiki/Manual:$wgLogo
+$wgLogo = "$mezaWikiIP/config/logo.png";
+
+// https://www.mediawiki.org/wiki/Manual:$wgFavicon
+$wgFavicon = "$mezaWikiIP/config/favicon.ico";
+
+// https://www.mediawiki.org/wiki/Manual:$wgMetaNamespace
+$wgMetaNamespace = str_replace( ' ', '_', $wgSitename );
+
+// @todo: handle auth type from setup.php
+// @todo: handle debug from setup.php
+
+// From MW web install: Uncomment this to disable output compression
+# $wgDisableOutputCompression = true;
+
+
+## The relative URL path to the skins directory
+$wgStylePath = "$wgScriptPath/skins";
+$wgResourceBasePath = $wgScriptPath;
+
 
 ## E-Mail
 $wgEnableEmail     = false; // true for production
@@ -47,9 +109,48 @@ if ( $wgEnableEmail ) {
 		'host'     => "your.email.server.com", // could also be an IP address
 		'IDHost'   => "your.server.com", // Generally the domain name of the website (aka mywiki.org)
 		'port'     => 25,    // Port to use when connecting to the SMTP server
-		'auth'     => false  // mrelay.jsc.nasa.gov doesn't require auth
+		'auth'     => false  // $host doesn't require auth
 	);
 }
+
+## UPO means: this is also a user preference option
+$wgEnableUserEmail = $wgEnableEmail; # UPO
+$wgEnotifUserTalk = false; # UPO
+$wgEnotifWatchlist = false; # UPO
+$wgEmailAuthentication = true;
+
+$wgEmergencyContact = str_replace(' ','-',$wgSitename) . '-Wiki@' . $IDHost;
+$wgPasswordSender = $wgEmergencyContact;
+
+## Database settings
+$wgDBtype = "mysql";
+$wgDBserver = "";
+if ( isset( $mezaCustomDBname ) ) {
+	$wgDBname = $mezaCustomDBname;
+} else {
+	$wgDBname = "wiki_$wikiId";
+}
+
+require_once "$m_htdocs/__common/defaultDatabaseCredentials.php";
+if ( isset( $mezaCustomDBuser ) && isset ( $mezaCustomDBpass ) ) {
+	$wgDBuser = $mezaCustomDBuser;
+	$wgDBpassword = $mezaCustomDBpass;
+}
+
+## Restrictions on who can view/edit
+## @todo: these just wired together for now. $mezaAuthType is from setup.php
+$egFodWikiSettings_auth_type = $mezaAuthType; // (ndc_closed) for local_dev add $wgTmpDirectory = 'd:\Support\php\uploadtemp';
+
+## Turn debug on if required
+$egFodWikiSettings_debug = $mezaDebug; // count: 23
+if ( isset( $_GET['emw_debug'] ) ) {
+	$egFodWikiSettings_debug = true; // count: 4
+}
+
+# Use FOD Wiki Settings - github/enterprisemediawiki/FodWikiSettings
+require_once "$IP/extensions/FodWikiSettings/FodWikiSettings.php";
+
+$wgGitBin = false;
 
 /**
  *  Code to load the extension "ExtensionLoader", which then installs and loads
@@ -64,17 +165,17 @@ foreach( ExtensionLoader::$loader->oldExtensions as $extensionPath ) {
 }
 ExtensionLoader::$loader->completeExtensionLoading();
 
+
+// @todo: do wiki specific stuff here (load extensions, override config, etc)
+if ( file_exists( "$m_htdocs/wikis/$wikiId/config/CustomSettings.php" ) ) {
+	require_once "$m_htdocs/wikis/$wikiId/config/CustomSettings.php";
+}
+
 ```
 
-### databaseCredentials.php
+### __common/defaultDatabaseCredentials.php
 ```
 <?php
-
-## Turn debug on if required
-$egFodWikiSettings_debug = false; // count: 23
-if ( isset( $_GET['emw_debug'] ) ) {
-	$egFodWikiSettings_debug = true; // count: 4
-}
 
 # DB1
 if( $wgCommandLineMode ) {


### PR DESCRIPTION
FOD2 will require slightly different settings for its farm setup:
- Several of the setup parameters are wiki-specific, and need to be handled on a per-wiki basis. For example, `$wgSitename` needs to be set based upon each wiki's name
- Many variables, particular relating to `$wgGroupPermissions` need to be called in the global context. I don't really understand why they don't need to be in the non-farm setup.
